### PR TITLE
Handle table row out of bounds error

### DIFF
--- a/Projects Folder/Fib_Golden_Level_Entry.pine
+++ b/Projects Folder/Fib_Golden_Level_Entry.pine
@@ -1,0 +1,262 @@
+//@version=5
+strategy("Fib Golden Level Entry", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=10)
+
+// ============================================================================
+// INPUTS
+// ============================================================================
+
+// Risk Management
+riskRewardRatio = input.float(2.0, "Risk/Reward Ratio", minval=1.0, maxval=5.0, step=0.1)
+stopLossPercent = input.float(1.0, "Stop Loss %", minval=0.1, maxval=5.0, step=0.1)
+
+// Fibonacci Levels
+fibRetrace618 = input.bool(true, "Use 61.8% Fib Level")
+fibRetrace786 = input.bool(false, "Use 78.6% Fib Level")
+
+// EMA Settings
+ema9Length = input.int(9, "EMA 9 Length", minval=1)
+ema21Length = input.int(21, "EMA 21 Length", minval=1)
+sma50Length = input.int(50, "SMA 50 Length", minval=1)
+
+// ADX Settings
+useADXFilter = input.bool(true, "Use ADX Filter")
+adxLength = input.int(14, "ADX Length", minval=1)
+adxThreshold = input.float(25.0, "ADX Threshold", minval=10.0, maxval=50.0)
+
+// Session Settings
+useSessionFilter = input.bool(true, "Use Session Filter")
+sessionStart = input.session("0930-1600", "Trading Session")
+
+// Debug Settings
+showDebugTable = input.bool(true, "Show Debug Table")
+
+// ============================================================================
+// CALCULATIONS
+// ============================================================================
+
+// EMAs and SMAs
+ema9 = ta.ema(close, ema9Length)
+ema21 = ta.ema(close, ema21Length)
+sma50 = ta.sma(close, sma50Length)
+
+// ADX
+[diplus, diminus, adx] = ta.dmi(adxLength, adxLength)
+
+// Session Filter
+inSession = not useSessionFilter or time(timeframe.period, sessionStart)
+
+// Fractal Detection Function
+isRegularFractal(mode) =>
+    ret = mode == 1 ? high[4] < high[3] and high[3] < high[2] and high[2] > high[1] and high[1] > high[0] :
+        mode == -1 ? low[4] > low[3] and low[3] > low[2] and low[2] < low[1] and low[1] < low[0] : false
+
+// Fractal Detection
+topFractal = isRegularFractal(1)   // Red fractals (high points)
+botFractal = isRegularFractal(-1)  // Green fractals (low points)
+
+// Function to find the actual fractal candle (the one with lowest low for bottom fractal)
+findFractalCandle() =>
+    var int fractalBar = na
+    if botFractal
+        // Find the candle with the lowest low among the previous 4 candles
+        lowestLow = math.min(low[1], math.min(low[2], math.min(low[3], low[4])))
+        if low[1] == lowestLow
+            fractalBar := 1
+        else if low[2] == lowestLow
+            fractalBar := 2
+        else if low[3] == lowestLow
+            fractalBar := 3
+        else if low[4] == lowestLow
+            fractalBar := 4
+    else
+        fractalBar := na
+    fractalBar
+
+// Get the fractal candle offset
+fractalOffset = findFractalCandle()
+
+// ============================================================================
+// BASE AND TOP LOGIC
+// ============================================================================
+
+// Variables for Base and Top
+var float baseValue = na
+var int baseBar = na
+var bool baseDefined = false
+var float topValue = na
+var int topBar = na
+var bool topDefined = false
+
+// Conditions
+allowNewBase = strategy.position_size == 0 or not baseDefined
+
+// Base Detection Logic
+if botFractal and allowNewBase and not na(fractalOffset)
+    // Check ADX condition for Base using the actual fractal bar
+    adxConditionBase = not useADXFilter or adx[fractalOffset] > adxThreshold
+    
+    // Check EMA conditions for Base using the actual fractal bar
+    emaConditionBase = ema9[fractalOffset] < ema21[fractalOffset] and ema21[fractalOffset] < sma50[fractalOffset]
+    
+    if adxConditionBase and emaConditionBase
+        // Force Base assignment when all conditions are met
+        baseValue := low[fractalOffset]  // Use the low from the fractal bar
+        baseBar := bar_index[fractalOffset]  // Use the bar index from the fractal bar
+        baseDefined := true
+        topDefined := false  // Reset Top when new Base is found
+        alert("Base Defined: " + str.tostring(low[fractalOffset]), alert.freq_once_per_bar)
+    else
+        if not adxConditionBase
+            alert("ADX Condition Failed", alert.freq_once_per_bar)
+        else if not emaConditionBase
+            alert("EMA Condition Failed", alert.freq_once_per_bar)
+    
+    // Force Base assignment for testing when all conditions are met
+    if botFractal and allowNewBase and not na(fractalOffset) and (not useADXFilter or adx[fractalOffset] > adxThreshold) and ema9[fractalOffset] < ema21[fractalOffset] and ema21[fractalOffset] < sma50[fractalOffset]
+        baseValue := low[fractalOffset]
+        baseBar := bar_index[fractalOffset]
+        baseDefined := true
+        topDefined := false
+        alert("FORCED Base Assignment", alert.freq_once_per_bar)
+else
+    if botFractal and not allowNewBase
+        alert("Allow New Base Failed", alert.freq_once_per_bar)
+
+// Top Detection Logic
+if topFractal and baseDefined and allowNewBase
+    // For top fractals, find the candle with the highest high among the previous 4 candles
+    highestHigh = math.max(high[1], math.max(high[2], math.max(high[3], high[4])))
+    topFractalOffset = high[1] == highestHigh ? 1 : high[2] == highestHigh ? 2 : high[3] == highestHigh ? 3 : 4
+    
+    // Check ADX condition for Top using the actual fractal bar
+    adxConditionTop = not useADXFilter or adx[topFractalOffset] > adxThreshold
+    
+    // Check EMA conditions for Top using the actual fractal bar
+    emaConditionTop = ema9[topFractalOffset] > ema21[topFractalOffset]
+    
+    if adxConditionTop and emaConditionTop
+        if not topDefined
+            topValue := high[topFractalOffset]  // Use the high from the fractal bar
+            topBar := bar_index[topFractalOffset]  // Use the bar index from the fractal bar
+            topDefined := true
+        else if high[topFractalOffset] > topValue and strategy.position_size == 0
+            topValue := high[topFractalOffset]  // Use the high from the fractal bar
+            topBar := bar_index[topFractalOffset]  // Use the bar index from the fractal bar
+
+// ============================================================================
+// FIBONACCI CALCULATIONS
+// ============================================================================
+
+// Calculate Fibonacci levels when both Base and Top are defined
+var float fib618 = na
+var float fib786 = na
+
+if baseDefined and topDefined
+    range = topValue - baseValue
+    fib618 := topValue - (range * 0.618)
+    fib786 := topValue - (range * 0.786)
+
+// ============================================================================
+// ENTRY CONDITIONS
+// ============================================================================
+
+// Long Entry Conditions
+longCondition = baseDefined and topDefined and inSession and 
+                ((fibRetrace618 and close <= fib618 and close > baseValue) or
+                 (fibRetrace786 and close <= fib786 and close > baseValue))
+
+if longCondition and strategy.position_size == 0
+    stopLoss = close * (1 - stopLossPercent / 100)
+    takeProfit = close + (close - stopLoss) * riskRewardRatio
+    
+    strategy.entry("Long", strategy.long)
+    strategy.exit("Exit Long", "Long", stop=stopLoss, limit=takeProfit)
+
+// ============================================================================
+// PLOTTING
+// ============================================================================
+
+// Plot EMAs
+plot(ema9, "EMA 9", color=color.blue, linewidth=1)
+plot(ema21, "EMA 21", color=color.red, linewidth=1)
+plot(sma50, "SMA 50", color=color.orange, linewidth=2)
+
+// Plot Base and Top
+plotshape(baseDefined ? baseValue : na, "Base", shape.triangleup, location.absolute, color.green, size=size.small)
+plotshape(topDefined ? topValue : na, "Top", shape.triangledown, location.absolute, color.red, size=size.small)
+
+// Plot Fibonacci levels
+plot(baseDefined and topDefined and fibRetrace618 ? fib618 : na, "Fib 61.8%", color=color.yellow, linewidth=1, style=plot.style_linebr)
+plot(baseDefined and topDefined and fibRetrace786 ? fib786 : na, "Fib 78.6%", color=color.purple, linewidth=1, style=plot.style_linebr)
+
+// ============================================================================
+// DEBUG TABLE
+// ============================================================================
+
+// Create debug table
+var table debugTable = table.new(position.top_right, 2, 21, bgcolor=color.black, border_width=1)
+
+// Update table data
+if showDebugTable and barstate.islast
+    table.cell(debugTable, 0, 0, "Base Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 0, baseDefined ? str.tostring(baseValue, "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 1, "Top Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 1, topDefined ? str.tostring(topValue, "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 2, "Fib 61.8%", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 2, (baseDefined and topDefined) ? str.tostring(fib618, "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 3, "Fib 78.6%", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 3, (baseDefined and topDefined) ? str.tostring(fib786, "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 4, "Current Price", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 4, str.tostring(close, "#.####"), text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 5, "ADX", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 5, str.tostring(adx, "#.##"), text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 6, "In Session", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 6, inSession ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 7, "EMA9 > EMA21", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 7, not na(fractalOffset) and ema9[fractalOffset] > ema21[fractalOffset] ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 8, "Allow New Base", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 8, allowNewBase ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 9, "Bot Fractal", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 9, botFractal ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 10, "Fractal Offset", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 10, not na(fractalOffset) ? str.tostring(fractalOffset) : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 11, "ADX Condition", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 11, (not useADXFilter or (not na(fractalOffset) and adx[fractalOffset] > adxThreshold)) ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 12, "EMA9 < EMA21", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 12, (not na(fractalOffset) and ema9[fractalOffset] < ema21[fractalOffset]) ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 13, "EMA21 < SMA50", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 13, (not na(fractalOffset) and ema21[fractalOffset] < sma50[fractalOffset]) ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 14, "All Base Conditions", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 14, (botFractal and allowNewBase and not na(fractalOffset) and (not useADXFilter or adx[fractalOffset] > adxThreshold) and ema9[fractalOffset] < ema21[fractalOffset] and ema21[fractalOffset] < sma50[fractalOffset]) ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 15, "Low[fractalOffset] Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 15, not na(fractalOffset) ? str.tostring(low[fractalOffset], "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 16, "Base Defined Status", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 16, baseDefined ? "TRUE" : "FALSE", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 17, "EMA Condition Base", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 17, (not na(fractalOffset) and ema9[fractalOffset] < ema21[fractalOffset] and ema21[fractalOffset] < sma50[fractalOffset]) ? "YES" : "NO", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 18, "EMA9[fractalOffset] Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 18, not na(fractalOffset) ? str.tostring(ema9[fractalOffset], "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 19, "EMA21[fractalOffset] Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 19, not na(fractalOffset) ? str.tostring(ema21[fractalOffset], "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)
+    
+    table.cell(debugTable, 0, 20, "SMA50[fractalOffset] Value", text_color=color.white, bgcolor=color.gray)
+    table.cell(debugTable, 1, 20, not na(fractalOffset) ? str.tostring(sma50[fractalOffset], "#.####") : "N/A", text_color=color.white, bgcolor=color.gray)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "Row out of table bounds" error by increasing debug table size and creating the Pine Script file.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The debug table was initialized with 20 rows (indices 0-19), but a cell was being written to row 20, causing an "out of table bounds" error. This PR increases the table size to 21 rows (indices 0-20) to resolve the issue and creates the complete `Fib_Golden_Level_Entry.pine` file.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8e15bdc-c9b5-4a19-a056-fb6c6f24d0ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8e15bdc-c9b5-4a19-a056-fb6c6f24d0ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>